### PR TITLE
Fixing DrabTestApp deployment crash

### DIFF
--- a/lib/drab/supervisor.ex
+++ b/lib/drab/supervisor.ex
@@ -18,7 +18,7 @@ defmodule Drab.Supervisor do
 
     # Run Drab Test App endpoint, when running tests or development
     children = case Code.ensure_compiled(DrabTestApp) do
-      {:error, :nofile} -> []
+      {:error, _} -> []
       {:module, DrabTestApp} -> [supervisor(DrabTestApp.Endpoint, [])]
     end 
 


### PR DESCRIPTION
Elixir 1.5.2
OTP 20.1

Starting an app with Drab in deployment is throwing:
```elixir
15:00:55.851 [info] Application drab exited: exited in: Drab.Supervisor.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (CaseClauseError) no case clause matching: {:error, :embedded}
            (drab) lib/drab/supervisor.ex:20: Drab.Supervisor.start/2
            (kernel) application_master.erl:273: :application_master.start_it_old/4
{"Kernel pid terminated",application_controller,"{application_start_failure,drab,{bad_return,{{'Elixir.Drab.Supervisor',start,[normal,[]]},{'EXIT',{{case_clause,{error,embedded}},[{'Elixir.Drab.Supervisor',start,2,[{file,\"lib/drab/supervisor.ex\"},{line,20}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,273}]}]}}}}}"}
```

It looks like it is missing a case clause at:  https://github.com/grych/drab/blob/master/lib/drab/supervisor.ex#L20

As per the docs at https://hexdocs.pm/elixir/Code.html#ensure_compiled/1 it can return a variety of different returns, and `{:error, :embedded}` is the one it returns when the system is deployed and no code can change (always assume the code exists in embedded mode if it is included at all).

Thus I'm altering the :error clause to be `{:error, :_}` as this file does not exist in your releases anyway (you really should be using a macro'd Mix environment call to test this).

Had to make the change locally as well, meaning it will be wiped when I update, so please have this PR in by then.  ^.^;