### PR TITLE
Bugfix of params parsing error caused by unsafe characters

### DIFF
--- a/lib/drab/core.ex
+++ b/lib/drab/core.ex
@@ -171,7 +171,7 @@ defmodule Drab.Core do
   @doc false
   def normalize_params(params) do
     Enum.reduce(params, "", fn {k, v}, acc ->
-      acc <> k <> "=" <> v <> "&"
+      acc <> k <> "=" <> URI.encode_www_form(v) <> "&"
     end)
     |> String.trim_trailing("&")
     |> Plug.Conn.Query.decode()


### PR DESCRIPTION
- (prob) unsafe user_input string breaks valid format of query_params
- (sol) add URI.encode_www_form to each input_values

this PR closes #57 