### PR TITLE
Functionality to get assigns from socket and displaying more tailored examples for users

### DIFF
--- a/lib/drab/channel.ex
+++ b/lib/drab/channel.ex
@@ -87,9 +87,8 @@ defmodule Drab.Channel do
       end) |> Enum.join(", ")
 
       live_example =
-        # if there are no assigns for the current socket, don't display `Live` example
         if assign_example do
-          %{Drab.Live => "socket |> poke(#{assign_example}: 42)"}
+          %{Drab.Live => "socket |> poke(#{assign_example}: \"This assign has been drabbed!\")"}
         else
           %{}
         end

--- a/lib/drab/channel.ex
+++ b/lib/drab/channel.ex
@@ -72,7 +72,7 @@ defmodule Drab.Channel do
       commander = Drab.get_commander(socket)
 
       assign_example =
-        case Drab.Live.socket_to_assigns(socket) do
+        case Drab.Live.assigns(socket) do
           [] ->
             nil
               
@@ -116,6 +116,10 @@ defmodule Drab.Channel do
 
           Examples:
       #{examples |> Enum.join("\n")}
+
+          If you want a list of the assigns for the current socket you can call the following:
+
+      Drab.Live.assigns(socket)
       """
     end
 

--- a/lib/drab/channel.ex
+++ b/lib/drab/channel.ex
@@ -70,19 +70,38 @@ defmodule Drab.Channel do
     # for debugging
     if IEx.started? do
       commander = Drab.get_commander(socket)
+
+      assign_example =
+        case Drab.Live.socket_to_assigns(socket) do
+          [] ->
+            nil
+              
+          [first_assign | _] ->
+            first_assign
+        end
+      
       modules = DrabModule.all_modules_for(commander.__drab__().modules)
       grouped = Enum.map(modules, fn module ->
         [_ | rest] = Module.split(module)
         Enum.join(rest, ".")
       end) |> Enum.join(", ")
 
-      module_examples = %{
-        Drab.Live     => "socket |> poke(count: 42)",
-        Drab.Element  => "socket |> set_style(backgroundColor: \"red\")",
+      live_example =
+        # if there are no assigns for the current socket, don't display `Live` example
+        if assign_example do
+          %{Drab.Live => "socket |> poke(#{assign_example}: 42)"}
+        else
+          %{}
+        end
+
+      other_examples = %{
+        Drab.Element  => "socket |> set_style(\"body\", backgroundColor: \"red\")",
         Drab.Query    => "socket |> select(:htmls, from: \"h4\")",
         Drab.Modal    => "socket |> alert(\"Title\", \"Sure?\", buttons: [ok: \"Azaliż\", cancel: \"Poniechaj\"])",
         Drab.Core     => "socket |> exec_js(\"alert('hello from IEx!')\")"
       }
+      
+      module_examples = Map.merge(live_example, other_examples)
       examples = Enum.map(modules, fn module ->
         module_examples[module]
       end) |> Enum.filter(fn x -> !is_nil(x) end)

--- a/lib/drab/channel.ex
+++ b/lib/drab/channel.ex
@@ -116,10 +116,6 @@ defmodule Drab.Channel do
 
           Examples:
       #{examples |> Enum.join("\n")}
-
-          If you want a list of the assigns for the current socket you can call the following:
-
-      Drab.Live.assigns(socket)
       """
     end
 

--- a/lib/drab/live.ex
+++ b/lib/drab/live.ex
@@ -374,11 +374,10 @@ defmodule Drab.Live do
   end
 
   @doc """
-  Returns a list of the assigns for the current socket.
+  Returns a list of the assigns for the main partial.
 
   Examples:
 
-      iex> socket = Drab.get_socket(pid("0.546.0"))
       iex> Drab.Live.assigns(socket)
       [:welcome_text]
   """
@@ -391,7 +390,6 @@ defmodule Drab.Live do
 
   Examples:
 
-      iex> socket = Drab.get_socket(pid("0.546.0"))
       iex> assigns(socket, "user.html")
       [:name, :age, :email]
   """
@@ -402,7 +400,6 @@ defmodule Drab.Live do
   @doc """
   Like `assigns/2`, but returns the assigns for a given combination of a `view` and a `partial`.
  
-      iex> socket = Drab.get_socket(pid("0.546.0"))
       iex> assigns(socket, MyApp.UserView, "user.html")
       [:name, :age, :email]
   """

--- a/lib/drab/live/crypto.ex
+++ b/lib/drab/live/crypto.ex
@@ -51,7 +51,7 @@ defmodule Drab.Live.Crypto do
     {secret, sign_secret}
   end
 
-  defp now_ms(), do: System.system_time(:milli_seconds)
+  defp now_ms(), do: System.system_time(:millisecond)
 
   @doc false
   def hash(term) do


### PR DESCRIPTION
I've made this PR to make the examples displayed to users for the Live Assigns slightly more tailored to their assigns.

The code added will allow for an assign to be fetched from their socket so that it can be displayed in the example and run without them having to edit the already given example. The `Live` example will be omitted if an example cannot be found.

I also modified the `set_style` example as it seemed like this one was outdated/wrong.

Apologies if there is a specific style guide or something that I've not found. You also mentioned on ElixirForum that the Drab.Live module was where a function for getting the assigns was appropriate, so that's where I put it.

Feel free to aggressively refactor this to your taste or give feedback so I can make it fit.
  