### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ config :phoenix, :template_engines,
   drab: Drab.Live.Engine
 
 config :drab, MyAppWeb.Endpoint,
-  otp_app: :my_app_web
+  otp_app: :my_app
 ```
 
   5. Add `:drab` to applications started by default in `mix.exs`:


### PR DESCRIPTION
by default the `otp_app:` option will not be `:my_app_web` module it'll be the base name of the project, or `:my_app`