### PR TITLE
Added function to delete socket process with reason :normal

### DIFF
--- a/lib/drab.ex
+++ b/lib/drab.ex
@@ -189,10 +189,22 @@ defmodule Drab do
     {:noreply, state}
   end
 
+  def terminate(reason, state) do
+    IO.puts "Process stoped by reason: #{inspect reason}"
+    {:stop, :normal, state}
+  end
+
   @doc false
   @spec handle_info(tuple, t) :: {:noreply, t}
   def handle_info({:EXIT, pid, :normal}, state) when pid != self() do
     # ignore exits of the subprocesses
+    {:noreply, state}
+  end
+
+  @doc false
+  @spec handle_info(tuple, t) :: {:noreply, t}
+  def handle_info({:EXIT, pid, :normal}, state) do
+    # get exits of the current procces
     {:noreply, state}
   end
 
@@ -276,6 +288,10 @@ defmodule Drab do
       {:reply, value, state}
     end
   end)
+
+  def handle_call(:delete_socket, _from, state) do
+    {:stop, :normal, state}
+  end
 
   @spec handle_callback(Phoenix.Socket.t(), atom, atom) :: Phoenix.Socket.t()
   defp handle_callback(socket, commander, callback) do
@@ -536,6 +552,10 @@ defmodule Drab do
       GenServer.cast(pid, {unquote(update_name), new_value})
     end
   end)
+
+  def delete_socket(pid) do
+    GenServer.stop(pid, :normal)
+  end
 
   @doc false
   @spec push_and_wait_for_response(Phoenix.Socket.t(), pid, String.t(), Keyword.t(), Keyword.t()) ::

--- a/lib/drab/core.ex
+++ b/lib/drab/core.ex
@@ -462,6 +462,24 @@ defmodule Drab.Core do
     # store(socket)[key]
   end
 
+  @doc false
+  @spec get_socket(pid) :: term
+  def get_socket(pid) when is_pid(pid) do
+    case Process.alive?(pid) do
+      true -> Drab.get_socket(pid)
+      false -> nil
+    end
+  end
+
+  @doc false
+  @spec get_socket(Phoenix.Socket.t()) :: term
+  def get_socket(%{assigns: %{__drab_pid: pid}}) do
+    case Process.alive?(pid) do
+      true -> Drab.get_socket(pid)
+      false -> nil
+    end
+  end
+
   @doc """
   Returns the value of the Drab store represented by the given key or `default` when key not found
 
@@ -498,6 +516,21 @@ defmodule Drab.Core do
   @spec save_socket(Phoenix.Socket.t()) :: :ok
   def save_socket(socket) do
     Drab.set_socket(Drab.pid(socket), socket)
+  end
+
+  @doc false
+  @spec delete_socket(pid) :: :ok
+  def delete_socket(pid) when is_pid(pid) do
+    case Process.alive?(pid) do
+      true -> Drab.delete_socket(pid)
+      false -> :ok
+    end
+  end
+
+  @doc false
+  @spec delete_socket(Phoenix.Socket.t()) :: :ok
+  def delete_socket(socket) do
+    Drab.delete_socket(Drab.pid(socket))
   end
 
   @doc """


### PR DESCRIPTION
Added functions:
in Drab
  ```
def delete_socket(pid) do
    GenServer.stop(pid, :normal)
  end
```
in Drab.Core
```
  @doc false
  @spec delete_socket(pid) :: :ok
  def delete_socket(pid) when is_pid(pid) do
    case Process.alive?(pid) do
      true -> Drab.delete_socket(pid)
      false -> :ok
    end
  end

  @doc false
  @spec delete_socket(Phoenix.Socket.t()) :: :ok
  def delete_socket(socket) do
    Drab.delete_socket(Drab.pid(socket))
  end
```