### PR TITLE
Adds support for allowing PubSub subscription and events handling

### DIFF
--- a/lib/drab/commander/config.ex
+++ b/lib/drab/commander/config.ex
@@ -4,6 +4,7 @@ defmodule Drab.Commander.Config do
   defstruct commander: nil,
             controller: nil,
             view: nil,
+            onload_init: nil,
             onload: nil,
             onconnect: nil,
             ondisconnect: nil,

--- a/test/integration/pubsub_test.exs
+++ b/test/integration/pubsub_test.exs
@@ -1,0 +1,33 @@
+defmodule DrabTestApp.PubsubTest do
+  import Drab.Live
+  use DrabTestApp.IntegrationCase
+
+  defp pubsub_index do
+    pubsub_url(DrabTestApp.Endpoint, :index)
+  end
+
+  setup do
+    pubsub_index() |> navigate_to()
+    # wait for the Drab to initialize
+    find_element(:id, "page_loaded_indicator")
+    [socket: drab_socket()]
+  end
+
+  describe "PubSub" do
+    test "Subscribed PubSub events should trigger `handle_info_message` in the Commander" do
+      socket = drab_socket()
+
+      # Changes some data in the db, this will trigger a PubSub event
+      DrabTestApp.Backend.append_element(42)
+
+      # Above operation is async, so wait a little bit
+      # for its completion before checking the result
+      Process.sleep(500)
+
+      # Check if the `handle_info_message` had changed the
+      # page assigns according to the new data
+      assert peek(socket, :status) == {:ok, "updated"}
+      assert peek(socket, :data) == {:ok, [1, 2, 3, 42]}
+    end
+  end
+end

--- a/test/support/lib/backend.ex
+++ b/test/support/lib/backend.ex
@@ -1,0 +1,31 @@
+defmodule DrabTestApp.Backend do
+  @moduledoc false
+
+  # PubSub support
+    @topic inspect(__MODULE__)
+    
+    def subscribe() do
+    	Phoenix.PubSub.subscribe(DrabTestApp.PubSub, @topic)
+    end
+
+    defp notify_subscribers({:ok, result}, event) do
+      Phoenix.PubSub.broadcast(DrabTestApp.PubSub, @topic, {__MODULE__, event, result})
+      {:ok, result}
+    end
+
+    defp notify_subscribers({:error, reason}, _event), do: {:error, reason}
+
+  # Fake db access
+    @fake_db [1, 2, 3]
+
+    def get_data() do
+    	@fake_db
+    end
+
+    def append_element(element) do
+      get_data()
+      |> List.insert_at(-1, element)
+      |> (&({:ok, &1})).()
+      |> notify_subscribers([:data, :updated])
+    end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -49,6 +49,8 @@ defmodule DrabTestApp.Router do
     get("/tests/live/broadcasting", LiveController, :broadcasting, as: :broadcasting)
 
     get("/tests/element", ElementController, :index, as: :element)
+    
+    get("/tests/pubsub", PubsubController, :index, as: :pubsub)
   end
 
   # Other scopes may use custom stacks.

--- a/test/support/web/commanders/pubsub_commander.ex
+++ b/test/support/web/commanders/pubsub_commander.ex
@@ -1,0 +1,21 @@
+defmodule DrabTestApp.PubsubCommander do
+  @moduledoc false
+
+  use Drab.Commander
+
+  onload_init(:do_init)
+  onload(:page_loaded)
+
+  def do_init() do
+    DrabTestApp.Backend.subscribe()
+  end
+
+  def page_loaded(socket) do
+    DrabTestApp.IntegrationCase.add_page_loaded_indicator(socket)
+    DrabTestApp.IntegrationCase.add_pid(socket)
+  end
+
+  def handle_info_message({DrabTestApp.Backend, [:data, :updated], result}, socket) do
+    poke(socket, status: "updated", data: result )
+  end
+end

--- a/test/support/web/controllers/element_controller.ex
+++ b/test/support/web/controllers/element_controller.ex
@@ -7,6 +7,6 @@ defmodule DrabTestApp.ElementController do
   require Logger
 
   def index(conn, _params) do
-    render(conn, "index.html")
+   render(conn, "index.html")
   end
 end

--- a/test/support/web/controllers/pubsub_controller.ex
+++ b/test/support/web/controllers/pubsub_controller.ex
@@ -1,0 +1,10 @@
+defmodule DrabTestApp.PubsubController do
+  @moduledoc false
+
+  use DrabTestApp.Web, :controller
+  require Logger
+
+  def index(conn, _params) do
+    render(conn, "index.html", status: "initilised", data: DrabTestApp.Backend.get_data())
+  end
+end

--- a/test/support/web/templates/pubsub/index.html.drab
+++ b/test/support/web/templates/pubsub/index.html.drab
@@ -1,0 +1,6 @@
+<h3 id="header">Drab Tests</h3>
+
+<div id="begin"></div>
+<div id="drab_pid"></div>
+
+<div>status_: <%= @status %> data: <%= inspect @data %></div>

--- a/test/support/web/views/pubsub_view.ex
+++ b/test/support/web/views/pubsub_view.ex
@@ -1,0 +1,5 @@
+defmodule DrabTestApp.PubsubView do
+  @moduledoc false
+
+  use DrabTestApp.Web, :view
+end


### PR DESCRIPTION
PubSub subscription requires the PID of the main process, but in the
Commander the events callbacks are spawned asynchronously and a
temporary PID is assigned to them, different from the main one.
For this reason we need a synchronous callback to be called in the
Commander where to put the call to the PubSub subscription.
This new synchronous callback `onload_init`, is called just before
calling the  `onload` callback.

The GenServer `handle_info` PubSub events are handled calling
the `handle_info_message/2` callbacks, that is expected to be present
in the Commander for any different combination of topic/message
subscribed.

The `handle_info_message/2` callback in the Commander expect a
message parameter, identical to the standard `handle_info/2` one,
and a socket parameter, instead of the GenServer `state` parameter.
It haven't to return anything.

The original `state` parameter will be returned by the internal handling
of the GenServer/PubSub event.