### PR TITLE
Allows Drab to support hot code upgrades

### DIFF
--- a/lib/drab/config.ex
+++ b/lib/drab/config.ex
@@ -284,8 +284,7 @@ defmodule Drab.Config do
   @spec drab_extension :: String.t()
   def drab_extension() do
     {drab_ext, Drab.Live.Engine} =
-      :phoenix
-      |> Application.get_env(:compiled_template_engines)
+      Phoenix.Template.engines()
       |> Enum.find(fn {_, v} -> v == Drab.Live.Engine end)
 
     "." <> to_string(drab_ext)


### PR DESCRIPTION
If an app in production is hot upgraded to a new version, Drab rises an alert with
"An error occured. Please contact the System Administrator" error message each time the user will try to interact with a Drab powered template.

This because in `Drab.Config.drab_extension()` the function `Application.fetch_env(:phoenix, :compiled_template_engines)` is used to retrieve the Drab custom engine, but this function returns `nil` after a hot code upgrade, so Drab will fail.

To safely get the list of compiled engines, the officially available API [`Phoenix.Template.engines/0`](https://hexdocs.pm/phoenix/Phoenix.Template.html#engines/0) should be used instead. [Internally](https://github.com/phoenixframework/phoenix/blob/v1.4.9/lib/phoenix/template.ex#L235), it dynamically rebuilds the list when necessary, and makes it statically available to the subsequent calls through `Application.fetch_env(:phoenix, :compiled_template_engines)`.