### PR TITLE
Liveview cohabitation

### DIFF
--- a/lib/drab/client.ex
+++ b/lib/drab/client.ex
@@ -148,16 +148,36 @@ defmodule Drab.Client do
   @spec api_version() :: String.t()
   def api_version(), do: @client_lib_version
 
+  @spec get_controller_module(Plug.Conn.t()) :: atom() | nil
+  defp get_controller_module(conn) do
+    try do
+      Phoenix.Controller.controller_module(conn)
+    rescue
+      KeyError -> 
+        nil
+    end
+  end
+
+  @spec get_controller_action_name(Plug.Conn.t()) :: atom() | nil
+  defp get_controller_action_name(conn) do
+    try do
+      Phoenix.Controller.action_name(conn)
+    rescue
+      KeyError -> nil
+    end    
+  end
+
   @spec generate_drab_js(Plug.Conn.t(), boolean, Keyword.t()) :: String.t()
   defp generate_drab_js(conn, connect?, assigns) do
-    if !conn.assigns[:live_view_module] do
-        controller = Phoenix.Controller.controller_module(conn)
+    if (controller = get_controller_module(conn)) do
+        # controller = Phoenix.Controller.controller_module(conn)
 
         if enables_drab?(controller) do
           commander = commander_for(controller)
           view = view_for(controller)
           endpoint = Phoenix.Controller.endpoint_module(conn)
-          action = Phoenix.Controller.action_name(conn)
+          # action = Phoenix.Controller.action_name(conn)
+          action = get_controller_action_name(conn)
 
           controller_and_action =
             Phoenix.Token.sign(


### PR DESCRIPTION
Currently it is not possible to use both Drab and LiveView in the same application because `Drab.Client.generate_drab_js/3` rises when it tries to get the controller module for a `LiveView` page, since a `:phoenix_controller` is not present in the conn of a page rendered by LiveView.

Namely, we have to check against the availability of a Controller before to try to access it instead of blindly assume that it is always available, as it was true in the world before the advent of LV.

This patch introduces two new helpers, `get_controller_module/1` and `get_controller_action_name/1`, that let `Drab.Client.generate_drab_js/3` to conditionally access the Controller data only when it is actually available.